### PR TITLE
Add the status DOCK_ERROR

### DIFF
--- a/imow/common/mowertask.py
+++ b/imow/common/mowertask.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 
 class MowerTask(Enum):
+    DOCK_ERROR = 1
     EDGE_MOWING = 5
     INSIDE_DOCK_NO_CHARGING = 6
     INSIDE_DOCK_CHARGING = 7


### PR DESCRIPTION
This error occurred yesterday:
![image](https://user-images.githubusercontent.com/198968/120112332-9fb97d00-c175-11eb-84e8-116701e81cf8.png)

I was not there, but was told that the mower was not in the docking station, but somewhere else in the garden, just sitting there. I dumped the mower object and this is the result:

```
{'accountId': '00000',
 'api': <imow.api.IMowApi object at 0x7f91e688d520>,
 'asmEnabled': False,
 'automaticModeEnabled': False,
 'boundryOffset': 60,
 'cModuleId': '048146fffe000000',
 'childLock': False,
 'circumference': 73,
 'codePage': 2,
 'coordinateLatitude': 39.127671,
 'coordinateLongitude': 22.950975,
 'corridorMode': 0,
 'demoModeEnabled': False,
 'deviceType': 24,
 'deviceTypeDescription': 'RMI 422 PC',
 'edgeMowingMode': 1,
 'endOfContract': '2000-01-01T00:00:00+00:00',
 'energyMode': 3,
 'externalId': '0000000443698502',
 'firmwareVersion': '01v013',
 'gdprAccepted': True,
 'gpsProtectionEnabled': True,
 'id': '00000',
 'imsi': '232010000000000',
 'lastWeatherCheck': '2021-05-29T00:53:41+00:00',
 'ledStatus': 7,
 'localTimezoneOffset': 690,
 'mappingIntelligentHomeDrive': 0,
 'mowerImageThumbnailUrl': 'https://app-cdn-appdata001-r-euwe-1b3d32.azureedge.net/device-images/mower-images/36745-15449427911-thumb.png',
 'mowerImageUrl': 'https://app-cdn-appdata001-r-euwe-1b3d32.azureedge.net/device-images/mower-images/36745-15424231911-photo.png',
 'name': 'daepp',
 'protectionLevel': 3,
 'rainSensorMode': 3,
 'smartLogic': {'dynamicMowingplan': True,
                'mowingArea': 400,
                'mowingAreaInFeet': 4000,
                'mowingAreaInMeter': 400,
                'mowingGrowthAdjustment': 0,
                'mowingTime': 7,
                'mowingTimeManual': False,
                'performedActivityTime': 4,
                'smartNotifications': True,
                'suggestedActivityTime': -129,
                'totalActivityActiveTime': 0,
                'weatherForecastEnabled': True},
 'softwarePacket': '12.05',
 'status': {'bladeService': False,
            'chargeLevel': 43,
            'extraStatus': 86,
            'extraStatus1': 0,
            'extraStatus2': 0,
            'extraStatus3': 4194304,
            'extraStatus4': 0,
            'extraStatus5': 0,
            'lastGeoPositionDate': '2021-05-29T19:59:27+00:00',
            'lastNoErrorMainState': 11,
            'lastSeenDate': '2021-05-29T19:49:09+00:00',
            'mainState': 1,
            'online': True,
            'rainStatus': False},
 'team': None,
 'teamable': False,
 'timeZone': 'Europe/Berlin',
 'unitFormat': 0,
 'version': '3.2.038'}
```

Later, the app said something like "offline in order to save battery", but unfortunately i did not save the status code.