### PR TITLE
docs: add tests/secrets.py.example for integration test setup

### DIFF
--- a/tests/secrets.py.example
+++ b/tests/secrets.py.example
@@ -1,0 +1,12 @@
+# Integration test credentials template
+# Copy this file to secrets.py and fill in real values.
+# NEVER commit secrets.py — it is listed in .gitignore.
+#
+# NOTE: The name `secrets` conflicts with Python's stdlib `secrets` module
+# (available since Python 3.6). If tests/secrets.py is missing, Python will
+# silently import the stdlib module and tests will fail with NameError.
+# See test_integration_imow.py for usage.
+
+EMAIL = "your-stihl-account@example.com"
+PASSWORD = "your-stihl-password"
+MOWER_NAME = "YourMowerName"


### PR DESCRIPTION
## Summary

Audit-driven addition of a credentials template for integration tests.

### Problem

`tests/test_integration_imow.py` imports credentials via `from secrets import *`, expecting a local `tests/secrets.py` file with `EMAIL`, `PASSWORD`, and `MOWER_NAME`. Two issues:

1. **No example file** — contributors have no template to work from and get confusing errors
2. **Module name conflict** — `secrets` is also a Python stdlib module (available since 3.6). If `tests/secrets.py` is missing, Python silently imports the stdlib `secrets` module instead, causing `NameError: name 'EMAIL' is not defined` with no obvious explanation

The file is already listed in `.gitignore` so real credentials cannot be accidentally committed.

### Change

Add `tests/secrets.py.example` documenting the required variables and warning about the stdlib naming conflict.

### Risk

Additive only — no existing code changed.
